### PR TITLE
Removed old scrolltop:false from nav

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -59,7 +59,7 @@
 </section>
 
 <div class="contain-to-grid sticky">
-  <nav class="top-bar" data-topbar data-options="scrolltop:false">
+  <nav class="top-bar" data-topbar>
     <ul class="title-area">
       <li class="name"><a href="/"><h1><span>Concordis</span></h1></a></li>
       <li class="toggle-topbar menu-icon"><a href="#"><span></span></a></li>


### PR DESCRIPTION
Removed old scrolltop:false data-option from nav to ensure navheight is
properly calculated prior to link to scroller performing its animation.
Note this also addresses the issue where the menu wasn’t always
collapsing on click.
